### PR TITLE
Back-arrow removed for large screens

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -73,4 +73,8 @@ section[data-testid='stSidebar'] {
     div[data-testid="collapsedControl"]{
         display: none;
     }
+
+    div[data-testid = "stSidebarCollapseButton"]{
+        display: none;
+    }
 }


### PR DESCRIPTION
### Description

I have removed the chevron-left arrow for larger screens (i.e. laptops and desktops) as it is not functional as hover effect is enabled and it is redundant. 

Fixes #128 
### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


